### PR TITLE
Refactor and fix promise chain handling  

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ There are many implementations of the concept of a `Promise`. This library aims 
 
 ***
 
-<a href="https://github.com/PhpGt/Promise/actions" target="_blank">
+<a href="https://github.com/phpgt/Promise/actions" target="_blank">
 	<img src="https://badge.status.php.gt/promise-build.svg" alt="Build status" />
 </a>
 <a href="https://app.codacy.com/gh/PhpGt/Promise" target="_blank">
@@ -18,14 +18,14 @@ There are many implementations of the concept of a `Promise`. This library aims 
 	<img src="https://badge.status.php.gt/promise-version.svg" alt="Current version" />
 </a>
 <a href="http://www.php.gt/promise" target="_blank">
-	<img src="https://badge.status.php.gt/promise-docs.svg" alt="PHP.Gt/Promise documentation" />
+	<img src="https://badge.status.php.gt/promise-docs.svg" alt="PHP.GT/Promise documentation" />
 </a>
 
 In computer science, a `Promise` is a mechanism that provides a simple and direct relationship between procedural code and asynchronous callbacks. Functions within procedural languages, like plain old PHP, have two ways they can affect your program's flow: either by returning values or throwing exceptions.
 
 When working with functions that execute asynchronously, we can't return values because they might not be ready yet, and we can't throw exceptions because that's a procedural concept (where should we catch them?). That's where promises come in: instead of returning a value or throwing an exception, your functions can return a `Promise`, which is an object that can be _fulfilled_ with a value, or _rejected_ with an exception, but not necessarily at the point that they are returned.
 
-With this concept, the actual work that calculates or loads the value required by your code can be _deferred_ to a task that executes asynchronously. Behind the scenes of PHP.Gt/Promise is a `Deferred` class that is used for exactly this.
+With this concept, the actual work that calculates or loads the value required by your code can be _deferred_ to a task that executes asynchronously. Behind the scenes of PHP.GT/Promise is a `Deferred` class that is used for exactly this.
 
 Example usage
 -------------
@@ -120,7 +120,7 @@ Event loop
 
 In order for this Promise library to be useful, some code has got to act as an event loop to call the deferred processes. This could be a simple while loop, but for real world tasks a more comprehensive loop system should be used.
 
-The implementation of a Promise-based architecture is complex enough on its own, so the responsibility of an event loop library is maintained separately in [PHP.Gt/Async][gt-async].
+The implementation of a Promise-based architecture is complex enough on its own, so the responsibility of an event loop library is maintained separately in [PHP.GT/Async][gt-async].
 
 Special thanks
 --------------

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,6 @@
 	colors="true"
 	cacheDirectory="test/phpunit/.phpunit.cache"
 	bootstrap="vendor/autoload.php"
-	displayDetailsOnTestsThatTriggerDeprecations="true"
 >
 	<coverage />
 

--- a/src/ExecutesPromiseChain.php
+++ b/src/ExecutesPromiseChain.php
@@ -1,0 +1,89 @@
+<?php
+namespace Gt\Promise;
+
+use Gt\Promise\Chain\CatchChain;
+use Gt\Promise\Chain\Chainable;
+use Gt\Promise\Chain\ChainFunctionTypeError;
+use Gt\Promise\Chain\FinallyChain;
+use Gt\Promise\Chain\ThenChain;
+
+trait ExecutesPromiseChain {
+	private function complete():void {
+		usort($this->chain, $this->sortChainItems(...));
+
+		while($this->getState() !== PromiseState::PENDING) {
+			$chainItem = $this->getNextChainItem();
+			if(!$chainItem) {
+				break;
+			}
+
+			if($this->shouldSkipResolution($chainItem)) {
+				continue;
+			}
+
+			if($chainItem instanceof ThenChain) {
+				$this->executeThen($chainItem);
+			}
+			elseif($chainItem instanceof FinallyChain) {
+				$this->executeFinally($chainItem);
+			}
+			elseif($chainItem instanceof CatchChain) {
+				$this->executeCatch($chainItem);
+			}
+		}
+
+		$this->throwUnhandledRejection();
+	}
+
+	private function shouldSkipResolution(Chainable $chainItem):bool {
+		if($chainItem instanceof ThenChain || $chainItem instanceof FinallyChain) {
+			try {
+				if($this->resolvedValueSet && isset($this->resolvedValue)) {
+					$chainItem->checkResolutionCallbackType($this->resolvedValue);
+				}
+			}
+			catch(ChainFunctionTypeError) {
+				return true;
+			}
+		}
+		elseif($chainItem instanceof CatchChain) {
+			try {
+				if(isset($this->rejectedReason)) {
+					$chainItem->checkRejectionCallbackType($this->rejectedReason);
+				}
+			}
+			catch(ChainFunctionTypeError) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function executeThen(ThenChain $chainItem):void {
+		if($this->handleThen($chainItem)) {
+			$this->emptyChain();
+		}
+	}
+
+	private function executeFinally(FinallyChain $chainItem):void {
+		if($this->handleFinally($chainItem)) {
+			$this->emptyChain();
+		}
+	}
+
+	private function executeCatch(CatchChain $chainItem):void {
+		if($handled = $this->handleCatch($chainItem)) {
+			array_push($this->handledRejections, $handled);
+		}
+	}
+
+	private function sortChainItems(Chainable $a, Chainable $b):int {
+		if($a instanceof FinallyChain && !($b instanceof FinallyChain)) {
+			return 1;
+		}
+		if($b instanceof FinallyChain && !($a instanceof FinallyChain)) {
+			return -1;
+		}
+		return 0;
+	}
+}

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -219,43 +219,34 @@ class Promise implements PromiseInterface {
 
 	private function handleFinally(FinallyChain $finally):bool {
 		if($this->getState() === PromiseState::RESOLVED) {
-			try {
-				$result = $finally->callOnResolved($this->resolvedValue);
-				if($result instanceof PromiseInterface) {
-					$this->chainPromise($result);
-				}
-				elseif(is_null($result)) {
-					$this->stopChain = true;
-					return true;
-				}
-				else {
-					$this->resolvedValue = $result;
-					$this->resolvedValueSet = true;
-					$this->tryComplete();
-				}
+			$result = $finally->callOnResolved($this->resolvedValue);
+			if($result instanceof PromiseInterface) {
+				$this->chainPromise($result);
 			}
-			catch(Throwable $reason) {
-				$this->reject($reason);
+			elseif(is_null($result)) {
+				$this->stopChain = true;
+				return true;
 			}
+			else {
+				$this->resolvedValue = $result;
+				$this->resolvedValueSet = true;
+				$this->tryComplete();
+			}
+
 		}
 		elseif($this->getState() === PromiseState::REJECTED) {
-			try {
-				$result = $finally->callOnRejected($this->rejectedReason);
-				if($result instanceof PromiseInterface) {
-					$this->chainPromise($result);
-				}
-				elseif(is_null($result)) {
-					$this->stopChain = true;
-					return true;
-				}
-				else {
-					$this->resolvedValue = $result;
-					$this->resolvedValueSet = true;
-					$this->tryComplete();
-				}
+			$result = $finally->callOnRejected($this->rejectedReason);
+			if($result instanceof PromiseInterface) {
+				$this->chainPromise($result);
 			}
-			catch(Throwable $reason) {
-				$this->reject($reason);
+			elseif(is_null($result)) {
+				$this->stopChain = true;
+				return true;
+			}
+			else {
+				$this->resolvedValue = $result;
+				$this->resolvedValueSet = true;
+				$this->tryComplete();
 			}
 		}
 

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -8,21 +8,15 @@ use Gt\Promise\Chain\FinallyChain;
 use Gt\Promise\Chain\ThenChain;
 use Throwable;
 
-/**
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @SuppressWarnings(PHPMD.CyclomaticComplexity)
- */
 class Promise implements PromiseInterface {
-	private mixed $resolvedValue;
-	/** @var bool This is required due to the ability to set `null` as a resolved value. */
 	private bool $resolvedValueSet = false;
-	private Throwable $rejectedReason;
+	private bool $stopChain = false;
 
-	/** @var Chainable[] */
+	private mixed $resolvedValue;
+	private mixed $originalResolvedValue;
+	private Throwable $rejectedReason;
 	private array $chain;
-	/** @var CatchChain[] */
 	private array $uncalledCatchChain;
-	/** @var Throwable[] */
 	private array $handledRejections;
 	/** @var callable */
 	private $executor;
@@ -31,7 +25,6 @@ class Promise implements PromiseInterface {
 		$this->chain = [];
 		$this->uncalledCatchChain = [];
 		$this->handledRejections = [];
-
 		$this->executor = $executor;
 		$this->callExecutor();
 	}
@@ -43,15 +36,11 @@ class Promise implements PromiseInterface {
 		elseif($this->resolvedValueSet) {
 			return PromiseState::RESOLVED;
 		}
-
 		return PromiseState::PENDING;
 	}
 
 	public function then(callable $onResolved):PromiseInterface {
-		array_push($this->chain, new ThenChain(
-			$onResolved,
-			null,
-		));
+		array_push($this->chain, new ThenChain($onResolved, null));
 		$this->tryComplete();
 		return $this;
 	}
@@ -59,7 +48,6 @@ class Promise implements PromiseInterface {
 	private function chainPromise(PromiseInterface $promise):void {
 		$this->reset();
 		$futureThen = $this->getNextChainItem();
-
 		$promise->then(function(mixed $newResolvedValue)use($futureThen) {
 			$futureThen->callOnResolved($newResolvedValue);
 			$this->resolve($newResolvedValue);
@@ -71,22 +59,13 @@ class Promise implements PromiseInterface {
 	}
 
 	public function catch(callable $onRejected):PromiseInterface {
-		array_push($this->chain, new CatchChain(
-			null,
-			$onRejected
-		));
+		array_push($this->chain, new CatchChain(null, $onRejected));
 		$this->tryComplete();
 		return $this;
 	}
 
-	public function finally(
-		callable $onResolvedOrRejected
-	):PromiseInterface {
-		array_push($this->chain, new FinallyChain(
-			$onResolvedOrRejected,
-			$onResolvedOrRejected
-		));
-
+	public function finally(callable $onResolvedOrRejected):PromiseInterface {
+		array_push($this->chain, new FinallyChain($onResolvedOrRejected, $onResolvedOrRejected));
 		return $this;
 	}
 
@@ -111,14 +90,16 @@ class Promise implements PromiseInterface {
 	}
 
 	private function resolve(mixed $value):void {
+		if($this->getState() !== PromiseState::PENDING) {
+			return;
+		}
 		$this->reset();
 		if($value instanceof PromiseInterface) {
 			$this->reject(new PromiseResolvedWithAnotherPromiseException());
 			$this->tryComplete();
 			return;
 		}
-
-		$this->resolvedValue = $value;
+		$this->resolvedValue = $this->originalResolvedValue = $value;
 		$this->resolvedValueSet = true;
 	}
 
@@ -137,6 +118,10 @@ class Promise implements PromiseInterface {
 	}
 
 	private function tryComplete():void {
+		if($this->stopChain) {
+			$this->stopChain = false;
+			return;
+		}
 		if(empty($this->chain)) {
 			$this->throwUnhandledRejection();
 			return;
@@ -146,54 +131,48 @@ class Promise implements PromiseInterface {
 		}
 	}
 
-	// phpcs:ignore
 	private function complete():void {
 		usort(
 			$this->chain,
 			function(Chainable $a, Chainable $b) {
-				if($a instanceof FinallyChain) {
-					return 1;
-				}
-				elseif($b instanceof FinallyChain) {
-					return -1;
-				}
-
+				if($a instanceof FinallyChain) return 1;
+				if($b instanceof FinallyChain) return -1;
 				return 0;
 			}
 		);
 
-		while($this->getState() !== PromiseState::PENDING) {
+		while ($this->getState() !== PromiseState::PENDING) {
 			$chainItem = $this->getNextChainItem();
-			if(!$chainItem) {
-				break;
-			}
+			if (!$chainItem) break;
 
-			if($chainItem instanceof ThenChain) {
+			if ($chainItem instanceof ThenChain) {
 				try {
 					if($this->resolvedValueSet && isset($this->resolvedValue)) {
 						$chainItem->checkResolutionCallbackType($this->resolvedValue);
 					}
 				}
-				catch(ChainFunctionTypeError) {
+				catch (ChainFunctionTypeError) {
 					continue;
 				}
 
-				$this->handleThen($chainItem);
+				if ($this->handleThen($chainItem)) {
+					$this->emptyChain();
+				}
 			}
-			elseif($chainItem instanceof CatchChain) {
+			elseif ($chainItem instanceof CatchChain) {
 				try {
-					if(isset($this->rejectedReason)) {
+					if (isset($this->rejectedReason)) {
 						$chainItem->checkRejectionCallbackType($this->rejectedReason);
 					}
-					if($handled = $this->handleCatch($chainItem)) {
+					if ($handled = $this->handleCatch($chainItem)) {
 						array_push($this->handledRejections, $handled);
 					}
 				}
-				catch(ChainFunctionTypeError) {
+				catch (ChainFunctionTypeError) {
 					continue;
 				}
 			}
-			elseif($chainItem instanceof FinallyChain) {
+			elseif ($chainItem instanceof FinallyChain) {
 				$this->handleFinally($chainItem);
 			}
 		}
@@ -205,30 +184,30 @@ class Promise implements PromiseInterface {
 		return array_shift($this->chain);
 	}
 
-	private function handleThen(ThenChain $then):void {
+	private function handleThen(ThenChain $then):bool {
 		if($this->getState() !== PromiseState::RESOLVED) {
-			return;
+			return false;
 		}
-
 		try {
-			$result = null;
-			if(isset($this->resolvedValue)) {
-				$result = $then->callOnResolved($this->resolvedValue);
-			}
-
+			$result = $then->callOnResolved($this->resolvedValue);
 			if($result instanceof PromiseInterface) {
 				$this->chainPromise($result);
 			}
 			elseif(is_null($result)) {
-				$this->reset();
+				$this->stopChain = true;
+				return true;
 			}
 			else {
-				$this->resolve($result);
+				$this->resolvedValue = $result;
+				$this->resolvedValueSet = true;
+				$this->tryComplete();
 			}
 		}
 		catch(Throwable $rejection) {
 			$this->reject($rejection);
 		}
+
+		return false;
 	}
 
 	private function handleCatch(CatchChain $catch):?Throwable {
@@ -236,10 +215,8 @@ class Promise implements PromiseInterface {
 			array_push($this->uncalledCatchChain, $catch);
 			return null;
 		}
-
 		try {
 			$result = $catch->callOnRejected($this->rejectedReason);
-
 			if($result instanceof PromiseInterface) {
 				$this->chainPromise($result);
 			}
@@ -249,25 +226,21 @@ class Promise implements PromiseInterface {
 			else {
 				return $this->rejectedReason;
 			}
-
 		}
 		catch(Throwable $rejection) {
 			$this->reject($rejection);
 		}
-
 		return null;
 	}
 
 	private function handleFinally(FinallyChain $finally):void {
 		$result = null;
-
 		if($this->getState() === PromiseState::RESOLVED) {
 			$result = $finally->callOnResolved($this->resolvedValue ?? null);
 		}
 		elseif($this->getState() === PromiseState::REJECTED) {
 			$result = $finally->callOnRejected($this->rejectedReason ?? null);
 		}
-
 		if($result instanceof PromiseInterface) {
 			$this->chainPromise($result);
 		}
@@ -282,5 +255,10 @@ class Promise implements PromiseInterface {
 				throw $this->rejectedReason;
 			}
 		}
+	}
+
+	protected function emptyChain():void {
+		$this->resolvedValue = $this->originalResolvedValue;
+		$this->chain = [];
 	}
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -90,7 +90,7 @@ class Promise implements PromiseInterface {
 	}
 
 	private function resolve(mixed $value):void {
-		if($this->getState() !== PromiseState::PENDING) {
+		if($this->getState() === PromiseState::RESOLVED) {
 			return;
 		}
 		$this->reset();

--- a/test/phpunit/DeferredTest.php
+++ b/test/phpunit/DeferredTest.php
@@ -79,4 +79,66 @@ class DeferredTest extends TestCase {
 		self::assertEquals(0, $numResolvedCalls);
 		self::assertEquals(1, $numRejectedCalls);
 	}
+
+	public function testMultipleResolution() {
+		$deferred = new Deferred();
+		$promise = $deferred->getPromise();
+
+		$received = [];
+
+		$deferred->resolve("hello");
+
+		$promise->then(function(string $thing) use(&$received) {
+// 0: Should resolve with "hello", from the above Deferred::resolve() call
+			array_push($received, $thing);
+			return "$thing-appended-from-1";
+		})->then(function(string $thing) use(&$received) {
+// 1: Should resolve with "hello-appended-from-1", due to the previous chained function returning the appended string.
+			array_push($received, $thing);
+// This function does not return a value...
+		})->then(function(mixed $thing) use(&$received) {
+// ... so this chained function should never be called.
+// Notice the type hint for the function is mixed, in case there's an attempt at resolving with null.
+			array_push($received, $thing);
+		});
+
+// 2: This function is at the start of a promise chain, which is already resolved, so it should be resolved with the original resolution of "hello".
+		$promise->then(function(string $thing) use(&$received) {
+			array_push($received, $thing);
+		});
+
+// 3: This function is also at the start of a new promise chain, so it should also be resolved with "hello".
+		$promise->then(function(string $thing) use(&$received) {
+			array_push($received, $thing);
+// but it doesn't return anything...
+		})->then(function(string $thing) use(&$received) {
+// ... so no future promises in this chain should be resolved.
+			array_push($received, $thing);
+		})->then(function(string $thing) use(&$received) {
+			array_push($received, $thing);
+		});
+
+// The Deferred is resolved with a new value, but the Promises/A+ specification
+// states that a promise should only resolve once, and subsequent resolutions
+// should be ignored.
+		$deferred->resolve("world");
+
+		$promise->then(function(string $thing) use(&$received) {
+// 4: This promise starts a new chain, so it should resolve with the original resolved value, "hello".
+			array_push($received, $thing);
+// but it doesn't return anything...
+		})->then(function(string $thing) use (&$received) {
+// ... so no future promises in this chain should be resolved.
+			array_push($received, $thing);
+		});
+
+// The count should match the commented behaviour above, to verify that chains
+// after a non-returning handler are not invoked.
+		self::assertCount(5, $received);
+		self::assertSame("hello", $received[0], "String check 0");
+		self::assertSame("hello-appended-from-1", $received[1], "String check 1");
+		self::assertSame("hello", $received[2], "String check 2");
+		self::assertSame("hello", $received[3], "String check 3");
+		self::assertSame("hello", $received[4], "String check 4");
+	}
 }

--- a/test/phpunit/PromiseTest.php
+++ b/test/phpunit/PromiseTest.php
@@ -460,14 +460,18 @@ class PromiseTest extends TestCase {
 		$sut = $promiseContainer->getPromise();
 		$sut->finally(function(mixed $resolvedValueOrRejectedReason) use($otherPromise, &$finallyLog) {
 			array_push($finallyLog, $resolvedValueOrRejectedReason);
+			return "First return";
+		})->finally(function(mixed $resolvedValueOrRejectedReason) use($otherPromise, &$finallyLog) {
+			array_push($finallyLog, $resolvedValueOrRejectedReason);
 			return $otherPromise;
 		})->finally(function(mixed $resolvedValueOrRejectedReason) use($otherPromise, &$finallyLog) {
 			array_push($finallyLog, $resolvedValueOrRejectedReason);
 		});
+
 		$promiseContainer->resolve("test");
 		self::assertCount(2, $finallyLog);
 		self::assertSame("test", $finallyLog[0]);
-		self::assertNull($finallyLog[1]);
+		self::assertSame("First return", $finallyLog[1]);
 	}
 
 	public function testOnRejectedCalledWhenFinallyThrows() {

--- a/test/phpunit/PromiseTest.php
+++ b/test/phpunit/PromiseTest.php
@@ -489,6 +489,9 @@ class PromiseTest extends TestCase {
 		})->catch(function(Throwable $reason) use(&$actualException) {
 			$actualException = $reason;
 		});
+
+		self::expectException(PromiseException::class);
+		self::expectExceptionMessage("Oh dear, oh dear");
 		$promiseContainer->resolve("Example resolution");
 		self::assertNull($actualException);
 	}


### PR DESCRIPTION
This pull request includes changes to improve promise chain handling, addressing issues in `finally` and rejection resolutions. It also refactors code for better readability and reduces complexity by removing duplication.  

### Changes  
- Fixed handling of `finally` within promise chains (#75).  
- Improved rejection handling to resolve chains with a static value (#75).  
- Fixed new issues in chain resolution, ensuring expected behavior (#75).  
- Added tests to validate exception handling when `catch` is not configured.  
- Began tests for unhandled promise rejections.  
- Simplified and refactored complex and duplicated code for maintainability.